### PR TITLE
pysofia-ml.<extension> does not deploy the binary module to the system.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='pysofia',
     url='http://pypi.python.org/pypi/pysofia',
     packages=['pysofia'],
     cmdclass = {'build_ext': build_ext},
-    ext_modules = [Extension('pysofia._sofia_ml',
+    ext_modules = [Extension('_sofia_ml',
         sources=sources,
         language='c++', include_dirs=[np.get_include()])],
 )


### PR DESCRIPTION
Remove pysofia-ml. makes it work like a charm

While testing the build on virtualenv (can't vouch for simple deployment), binary module does not get deployed. Running the included tests responds with 

```
ss@shakti:/tmp/pysofia$ python test.py 
  Traceback (most recent call last):
     File "test.py", line 3, in <module>
        from pysofia import sgd_train, sgd_predict
     File "/tmp/pysofia/pysofia/__init__.py", line 1, in <module>
        from sofia_ml import sgd_train, sgd_predict
     File "/tmp/pysofia/pysofia/sofia_ml.py", line 4, in <module>
        import _sofia_ml
 ImportError: No module named _sofia_ml
```
